### PR TITLE
Fixes it working with Go Get

### DIFF
--- a/Client/client.go
+++ b/Client/client.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	pb "github.com/taylorflatt/Lab1"
+	pb "github.com/taylorflatt/remote-shell"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/Server/server.go
+++ b/Server/server.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"os/exec"
 
-	pb "github.com/taylorflatt/Lab1"
+	pb "github.com/taylorflatt/remote-shell"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"


### PR DESCRIPTION
Without this change the Go compiler is looking for a Lab1 folder that does not exist.